### PR TITLE
Updated so that there is a relative path to projects. 

### DIFF
--- a/duanemckdev.dotnet.tools.testx/MsBuildProjectFinder.cs
+++ b/duanemckdev.dotnet.tools.testx/MsBuildProjectFinder.cs
@@ -5,107 +5,107 @@ using System.Linq;
 
 namespace duanemckdev.dotnet.tools.testx
 {
-    // https://raw.githubusercontent.com/aspnet/DotNetTools/master/src/dotnet-watch/Internal/MsBuildProjectFinder.cs
-    public class MsBuildProjectFinder
-    {
-        public static string FindMsBuildProject(string searchBase, string project)
-        {
+	// https://raw.githubusercontent.com/aspnet/DotNetTools/master/src/dotnet-watch/Internal/MsBuildProjectFinder.cs
+	public class MsBuildProjectFinder
+	{
+		public static string FindMsBuildProject(string searchBase, string project)
+		{
 
-            var projectPath = project ?? searchBase;
+			var projectPath = project ?? searchBase;
 
-            if (!Path.IsPathRooted(projectPath))
-            {
-                projectPath = Path.Combine(searchBase, projectPath);
-            }
+			if (!Path.IsPathRooted(projectPath))
+			{
+				projectPath = Path.Combine(searchBase, projectPath);
+			}
 
-            if (Directory.Exists(projectPath))
-            {
-                var projects = Directory.EnumerateFileSystemEntries(projectPath, "*.*proj", SearchOption.TopDirectoryOnly)
-                    .Where(f => !".xproj".Equals(Path.GetExtension(f), StringComparison.OrdinalIgnoreCase))
-                    .ToList();
+			if (Directory.Exists(projectPath))
+			{
+				var projects = Directory.EnumerateFileSystemEntries(projectPath, "*.*proj", SearchOption.TopDirectoryOnly)
+					.Where(f => !".xproj".Equals(Path.GetExtension(f), StringComparison.OrdinalIgnoreCase))
+					.ToList();
 
-                if (projects.Count > 1)
-                {
-                    throw new FileNotFoundException($"Multiple projects found in {projectPath}");
-                }
+				if (projects.Count > 1)
+				{
+					throw new FileNotFoundException($"Multiple projects found in {projectPath}");
+				}
 
-                if (projects.Count == 0)
-                {
-                    throw new FileNotFoundException($"No projects found in {projectPath}");
-                }
+				if (projects.Count == 0)
+				{
+					throw new FileNotFoundException($"No projects found in {projectPath}");
+				}
 
-                return projects[0];
-            }
+				return projects[0];
+			}
 
-            if (!File.Exists(projectPath))
-            {
-                throw new FileNotFoundException($"Projects not found {projectPath}");
-            }
+			if (!File.Exists(projectPath))
+			{
+				throw new FileNotFoundException($"Projects not found {projectPath}");
+			}
 
-            return projectPath;
-        }
+			return projectPath;
+		}
 
-        private static string DetectSolutionFile(int attemptsLeft, string folder)
-        {
-            if (folder == null)
-            {
-                return null;
-            }
-            var thisFolder = new DirectoryInfo(folder);
-            var solutionFileExists = thisFolder.GetFiles("*.sln").Any();
-            if (solutionFileExists)
-            {
-                return folder;
-            }
+		private static string DetectSolutionFile(int attemptsLeft, string folder)
+		{
+			if (folder == null)
+			{
+				return null;
+			}
+			var thisFolder = new DirectoryInfo(folder);
+			var solutionFileExists = thisFolder.GetFiles("*.sln").Any();
+			if (solutionFileExists)
+			{
+				return folder;
+			}
 
-            if (attemptsLeft > 0)
-            {
-                return DetectSolutionFile(attemptsLeft - 1, thisFolder.Parent?.FullName);
-            }
+			if (attemptsLeft > 0)
+			{
+				return DetectSolutionFile(attemptsLeft - 1, thisFolder.Parent?.FullName);
+			}
 
-            return null;
-        }
+			return null;
+		}
 
-        public static IEnumerable<string> FindAllProjectsInFolder(string root, string pattern, bool verbose)
-        {
-            var solutionFolder = DetectSolutionFile(3, root);
-            if (solutionFolder != null)
-            {
-                root = solutionFolder;
-                if (verbose)
-                {
-                    Console.Out.WriteLine($"Working directory does not have a solution, moved up to {root}");
-                }
-            }
-            var files = new List<FileInfo>();
-            TraverseAndLocateProjectFiles(files, new DirectoryInfo(root), pattern, verbose);
-            if (!files.Any())
-            {
-                throw new Exception($"No projects found in {root}");
-            }
-            Console.Out.WriteLine(files.Aggregate("Found the following projects:\n", (output, file) => $"{output}\t- {file.Name}\n").Trim());
-            return files.Select(f => f.FullName);
-        }
+		public static IEnumerable<string> FindAllProjectsInFolder(string root, string pattern, bool verbose)
+		{
+			var solutionFolder = DetectSolutionFile(3, root);
+			if (solutionFolder != null)
+			{
+				root = solutionFolder;
+				if (verbose)
+				{
+					Console.Out.WriteLine($"Working directory does not have a solution, moved up to {root}");
+				}
+			}
+			var files = new List<FileInfo>();
+			TraverseAndLocateProjectFiles(files, new DirectoryInfo(root), pattern, verbose);
+			if (!files.Any())
+			{
+				throw new Exception($"No projects found in {root}");
+			}
+			Console.Out.WriteLine(files.Aggregate("Found the following projects:\n", (output, file) => $"{output}\t- {file.Name}\n").Trim());
+			return files.Select(f => Path.Combine(Path.GetRelativePath(root, f.DirectoryName), f.Name));
+		}
 
-        private static void TraverseAndLocateProjectFiles(List<FileInfo> projectFiles, DirectoryInfo folder, string pattern, bool verbose)
-        {
-            if (verbose)
-            {
-                Console.Out.WriteLine($"Searching...{folder} for {pattern}");
-            }
+		private static void TraverseAndLocateProjectFiles(List<FileInfo> projectFiles, DirectoryInfo folder, string pattern, bool verbose)
+		{
+			if (verbose)
+			{
+				Console.Out.WriteLine($"Searching...{folder} for {pattern}");
+			}
 
-            var files = folder.GetFiles(pattern);
-            if (verbose)
-            {
-                Console.Out.WriteLine($"Found {files.Length} files matching pattern");
-            }
+			var files = folder.GetFiles(pattern);
+			if (verbose)
+			{
+				Console.Out.WriteLine($"Found {files.Length} files matching pattern");
+			}
 
-            projectFiles.AddRange(files);
-            foreach (var subFolder in folder.GetDirectories())
-            {
-                TraverseAndLocateProjectFiles(projectFiles, subFolder, pattern, verbose);
-            }
-        }
-    }
+			projectFiles.AddRange(files);
+			foreach (var subFolder in folder.GetDirectories())
+			{
+				TraverseAndLocateProjectFiles(projectFiles, subFolder, pattern, verbose);
+			}
+		}
+	}
 }
 

--- a/duanemckdev.dotnet.tools.testx/Options.cs
+++ b/duanemckdev.dotnet.tools.testx/Options.cs
@@ -38,5 +38,8 @@ namespace duanemckdev.dotnet.tools.testx
 
         [Option("verbose", Required = false, Default = false, HelpText = "Log more verbose details of whats happening")]
         public bool Verbose { get; set; }
-    }
+
+		[Option("working-dir", Required = false, Default = null, HelpText = "Sets the working directory of the application")]
+		public string WorkingDirectory { get; set; }
+	}
 }

--- a/duanemckdev.dotnet.tools.testx/Runners/CoberturaRunner.cs
+++ b/duanemckdev.dotnet.tools.testx/Runners/CoberturaRunner.cs
@@ -6,7 +6,7 @@ namespace duanemckdev.dotnet.tools.testx.runners
     {
         private readonly string _exe;
         
-        public CoberturaRunner(string exe, bool verbose) : base(verbose)
+        public CoberturaRunner(string workingDirectory,string exe, bool verbose) : base(workingDirectory,verbose)
         {
             _exe = exe;
         }

--- a/duanemckdev.dotnet.tools.testx/Runners/OpenCoverRunner.cs
+++ b/duanemckdev.dotnet.tools.testx/Runners/OpenCoverRunner.cs
@@ -7,8 +7,8 @@ namespace duanemckdev.dotnet.tools.testx.runners
         protected readonly string _exe;
         private const string dotnetExe = @"C:\Program Files\dotnet\dotnet.exe";
 
-        public OpenCoverRunner(string exe, bool verbose) : base(verbose)
-        {
+        public OpenCoverRunner(string workingDirectory, string exe, bool verbose) : base(workingDirectory, verbose)
+		{
             _exe = exe;
         }
 

--- a/duanemckdev.dotnet.tools.testx/Runners/ProcessExecutor.cs
+++ b/duanemckdev.dotnet.tools.testx/Runners/ProcessExecutor.cs
@@ -3,34 +3,37 @@ using System.Diagnostics;
 
 namespace duanemckdev.dotnet.tools.testx.runners
 {
-    public class ProcessExecutor
-    {
-        private readonly bool _verbose;
+	public class ProcessExecutor
+	{
+		private readonly bool _verbose;
+		private readonly string _workingDirectory;
 
-        public ProcessExecutor(bool verbose)
-        {
-            _verbose = verbose;
-        }
+		public ProcessExecutor(string workingDirectory, bool verbose)
+		{
+			_verbose = verbose;
+			_workingDirectory = workingDirectory;
+		}
 
-        protected int RunAndWait(string exe, string args)
-        {
-            if (_verbose)
-            {
-                Console.Out.WriteLine("Executing:");
-                Console.Out.WriteLine($"\t{exe} {args}");
-                Console.Out.WriteLine("\nNOTE: All further output will be from the process");
-                Console.Out.WriteLine("-------------------------------------------------------------");
-            }
+		protected int RunAndWait(string exe, string args)
+		{
+			if (_verbose)
+			{
+				Console.Out.WriteLine("Executing:");
+				Console.Out.WriteLine($"\t{exe} {args}");
+				Console.Out.WriteLine("\nNOTE: All further output will be from the process");
+				Console.Out.WriteLine("-------------------------------------------------------------");
+			}
 
-            ProcessStartInfo psi = new ProcessStartInfo
-            {
-                Arguments = args,
-                FileName = exe
-            };
-            var process = Process.Start(psi);
-            process?.WaitForExit();
-            var exitCode = process?.ExitCode ?? 1;            
-            return exitCode;
-        }
-    }
+			ProcessStartInfo psi = new ProcessStartInfo
+			{
+				Arguments = args,
+				FileName = exe,
+				WorkingDirectory = _workingDirectory
+			};
+			var process = Process.Start(psi);
+			process?.WaitForExit();
+			var exitCode = process?.ExitCode ?? 1;
+			return exitCode;
+		}
+	}
 }

--- a/duanemckdev.dotnet.tools.testx/Runners/ReportGenerator.cs
+++ b/duanemckdev.dotnet.tools.testx/Runners/ReportGenerator.cs
@@ -4,8 +4,8 @@
     {
         private readonly string _exe;
 
-        public ReportGeneratorRunner(string exe, bool verbose) : base(verbose)
-        {
+        public ReportGeneratorRunner(string workingDirectory, string exe, bool verbose) : base(workingDirectory, verbose)
+		{
             _exe = exe;
         }
 

--- a/duanemckdev.dotnet.tools.testx/TestXRunner.cs
+++ b/duanemckdev.dotnet.tools.testx/TestXRunner.cs
@@ -1,174 +1,178 @@
-﻿using System;
+﻿using CSharpx;
+using duanemckdev.dotnet.tools.testx.resolvers;
+using duanemckdev.dotnet.tools.testx.runners;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using CSharpx;
-using duanemckdev.dotnet.tools.testx.resolvers;
-using duanemckdev.dotnet.tools.testx.runners;
 
 namespace duanemckdev.dotnet.tools.testx
 {
-    public class TestXRunner
-    {
-        private const string CoverageLocation = "coverage";
-        private static readonly string ResultsFile = $"{CoverageLocation}\\results.xml";
-        private static readonly string CoberturaFile = $"{CoverageLocation}\\cobertura.xml";
-        private static readonly string ReportFolder = $"{CoverageLocation}\\htmlreport";
-        private readonly Options _options;
+	public class TestXRunner
+	{
+		private const string CoverageLocation = "coverage";
+		private static readonly string ResultsFile = $"{CoverageLocation}\\results.xml";
+		private static readonly string CoberturaFile = $"{CoverageLocation}\\cobertura.xml";
+		private static readonly string ReportFolder = $"{CoverageLocation}\\htmlreport";
+		private readonly Options _options;
 
-        public TestXRunner(Options options)
-        {
-            _options = options;
-            if (options.Verbose)
-            {
-                LogOptions();
-            }
-        }
+		public TestXRunner(Options options)
+		{
+			_options = options;
 
-        public int Run()
-        {
-            try
-            {
-                IEnumerable<int> exitCodes = null;
-                CleanupPreviousResults();
-                if (_options.Project == "all")
-                {
-                    _options.RunForAllProjects = "*Tests.csproj";
-                }
-                if (_options.RunForAllProjects != null)
-                {
-                    LogHeader($"Discovering projects with pattern {_options.RunForAllProjects}");
-                    var projectFiles = MsBuildProjectFinder.FindAllProjectsInFolder(Directory.GetCurrentDirectory(),
-                        _options.RunForAllProjects, _options.Verbose);
-                    LogFooter();
-                    exitCodes = projectFiles.Select(RunForProject).ToList();                    
-                }
-                else
-                {
-                    var projectFile =
-                        MsBuildProjectFinder.FindMsBuildProject(Directory.GetCurrentDirectory(), _options.Project);
-                    var exitCode = RunForProject(projectFile);
-                    exitCodes = new List<int>(){exitCode};
-                }
+			_options.WorkingDirectory = string.IsNullOrWhiteSpace(_options.WorkingDirectory) ? Directory.GetCurrentDirectory() : _options.WorkingDirectory;
+			if (options.Verbose)
+			{
+				LogOptions();
+			}
+		}
 
-                GenerateReports();
-                LogHeader($"Coverage results in {CoverageLocation}");
-                LogFooter();
+		public int Run()
+		{
+			try
+			{
 
-                if (exitCodes.Any(code => code != 0))
-                {
-                    Console.Error.WriteLine("One or more of the test executions exited with non-zero exit code");
-                    return 1;
-                }
-                return 0;
-            }
-            catch (ProcessException processException)
-            {
-                Console.Error.WriteLine(processException.Message);
-                return processException.ExitCode;
-            }
-            catch (Exception exception)
-            {
-                Console.Error.WriteLine(exception.Message);
-                Console.Error.WriteLine(exception.StackTrace);
-                return 1;
-            }
-        }
 
-        private void CleanupPreviousResults()
-        {
-            if (Directory.Exists(CoverageLocation))
-            {
-                Directory.Delete(CoverageLocation, true);
-                
-            }
-            Directory.CreateDirectory(CoverageLocation);
-        }
+				IEnumerable<int> exitCodes = null;
+				CleanupPreviousResults();
+				if (_options.Project == "all")
+				{
+					_options.RunForAllProjects = "*Tests.csproj";
+				}
+				if (_options.RunForAllProjects != null)
+				{
+					LogHeader($"Discovering projects with pattern {_options.RunForAllProjects}");
+					var projectFiles = MsBuildProjectFinder.FindAllProjectsInFolder(_options.WorkingDirectory,
+						_options.RunForAllProjects, _options.Verbose);
+					LogFooter();
+					exitCodes = projectFiles.Select(RunForProject).ToList();
+				}
+				else
+				{
+					var projectFile =
+						MsBuildProjectFinder.FindMsBuildProject(_options.WorkingDirectory, _options.Project);
+					var exitCode = RunForProject(projectFile);
+					exitCodes = new List<int>() { exitCode };
+				}
 
-        private void LogOptions()
-        {
-            LogHeader("Options");
-            if (_options.RunForAllProjects != null)
-            {
-                Console.Out.WriteLine($"\t Will discover projects with pattern {_options.RunForAllProjects}");
-            }
-            else if (_options.Project != null)
-            {
-                Console.Out.WriteLine($"\t Will run with project {_options.Project}");
-            }
-            else
-            {
-                Console.Out.WriteLine($"\t No project specified, will try find one in working directory");
-            }
+				GenerateReports();
+				LogHeader($"Coverage results in {CoverageLocation}");
+				LogFooter();
 
-            Console.Out.WriteLine($"\t Test results format: {_options.TestResultsFormat}");
-            Console.Out.WriteLine($"\t OpenCover filters: {_options.OpenCoverFilters}");
-            if (_options.OpenCoverVersion != null)
-            {
-                Console.Out.WriteLine($"\t Override OpenCover version to: {_options.OpenCoverVersion}");
-            }
+				if (exitCodes.Any(code => code != 0))
+				{
+					Console.Error.WriteLine("One or more of the test executions exited with non-zero exit code");
+					return 1;
+				}
+				return 0;
+			}
+			catch (ProcessException processException)
+			{
+				Console.Error.WriteLine(processException.Message);
+				return processException.ExitCode;
+			}
+			catch (Exception exception)
+			{
+				Console.Error.WriteLine(exception.Message);
+				Console.Error.WriteLine(exception.StackTrace);
+				return 1;
+			}
+		}
 
-            Console.Out.WriteLine($"\t Will{(_options.OpenCoverMerge?"":" NOT")} merge open cover reports");
-            Console.Out.WriteLine($"\t Will{(_options.Cobertura ? "" : " NOT")} generate cobertura format report");
-            Console.Out.WriteLine($"\t Will{(_options.GenerateReport ? "" : " NOT")} generate HTML report");
-            Console.Out.WriteLine($"\t Will{(_options.LaunchBrowser ? "" : " NOT")} launch browser with HTML report");
-            LogFooter();
-        }
+		private void CleanupPreviousResults()
+		{
+			if (Directory.Exists(CoverageLocation))
+			{
+				Directory.Delete(CoverageLocation, true);
 
-        private int RunForProject(string projectFile)
-        {
-            var openCoverExe = new OpenCoverResolver().Resolve(_options.OpenCoverVersion);
-            
-            LogHeader($"Running tests (instrumented by OpenCover) for {projectFile}", true);
-            var exitCode = new OpenCoverRunner(openCoverExe, _options.Verbose).Run(projectFile, _options.OpenCoverFilters, ResultsFile, _options.OpenCoverMerge, _options.OpenCoverOptions);
-            LogFooter();
-            return exitCode;
-        }
+			}
+			Directory.CreateDirectory(CoverageLocation);
+		}
 
-        private  void GenerateReports()
-        {
-            if (_options.GenerateReport)
-            {
-                LogHeader("Generating HTML Report");
-                var reporterExe = new ReportGeneratorResolver().Resolve(null);
-                new ReportGeneratorRunner(reporterExe, _options.Verbose).GenerateReport(ResultsFile, ReportFolder);
+		private void LogOptions()
+		{
+			LogHeader("Options");
+			if (_options.RunForAllProjects != null)
+			{
+				Console.Out.WriteLine($"\t Will discover projects with pattern {_options.RunForAllProjects}");
+			}
+			else if (_options.Project != null)
+			{
+				Console.Out.WriteLine($"\t Will run with project {_options.Project}");
+			}
+			else
+			{
+				Console.Out.WriteLine($"\t No project specified, will try find one in working directory");
+			}
 
-                if (_options.LaunchBrowser)
-                {
-                    HtmlLauncher.OpenBrowser($"{ReportFolder}\\index.htm");
-                }
+			Console.Out.WriteLine($"\t Test results format: {_options.TestResultsFormat}");
+			Console.Out.WriteLine($"\t OpenCover filters: {_options.OpenCoverFilters}");
+			if (_options.OpenCoverVersion != null)
+			{
+				Console.Out.WriteLine($"\t Override OpenCover version to: {_options.OpenCoverVersion}");
+			}
 
-                LogFooter();
-            }
+			Console.Out.WriteLine($"\t Will{(_options.OpenCoverMerge ? "" : " NOT")} merge open cover reports");
+			Console.Out.WriteLine($"\t Will{(_options.Cobertura ? "" : " NOT")} generate cobertura format report");
+			Console.Out.WriteLine($"\t Will{(_options.GenerateReport ? "" : " NOT")} generate HTML report");
+			Console.Out.WriteLine($"\t Will{(_options.LaunchBrowser ? "" : " NOT")} launch browser with HTML report");
+			LogFooter();
+		}
 
-            if (_options.Cobertura)
-            {
-                LogHeader("Generating Cobertura Report");
-                var converterExe = new CoberturaResolver().Resolve(null);
-                new CoberturaRunner(converterExe, _options.Verbose).Run(ResultsFile, CoberturaFile);
-                LogFooter();
-            }
-        }
+		private int RunForProject(string projectFile)
+		{
+			var openCoverExe = new OpenCoverResolver().Resolve(_options.OpenCoverVersion);
 
-        private void LogHeader(string message, bool forceLog = false)
-        {
-            if (_options.Verbose || forceLog)
-            {
-                Console.Out.WriteLine(
-                    "======================================================================================================================================================");
-                Console.Out.WriteLine($"\t{message}");
-                Console.Out.WriteLine(
-                    "------------------------------------------------------------------------------------------------------------------------------------------------------");
-            }
-        }
+			LogHeader($"Running tests (instrumented by OpenCover) for {projectFile}", true);
+			var exitCode = new OpenCoverRunner(_options.WorkingDirectory, openCoverExe, _options.Verbose).Run(projectFile, _options.OpenCoverFilters, ResultsFile, _options.OpenCoverMerge, _options.OpenCoverOptions);
+			LogFooter();
+			return exitCode;
+		}
 
-        private void LogFooter()
-        {
-            if (_options.Verbose)
-            {
-                Console.Out.WriteLine(
-                    "======================================================================================================================================================");
-            }
-        }
-    }
+		private void GenerateReports()
+		{
+			if (_options.GenerateReport)
+			{
+				LogHeader("Generating HTML Report");
+				var reporterExe = new ReportGeneratorResolver().Resolve(null);
+				new ReportGeneratorRunner(_options.WorkingDirectory, reporterExe, _options.Verbose).GenerateReport(ResultsFile, ReportFolder);
+
+				if (_options.LaunchBrowser)
+				{
+					HtmlLauncher.OpenBrowser($"{ReportFolder}\\index.htm");
+				}
+
+				LogFooter();
+			}
+
+			if (_options.Cobertura)
+			{
+				LogHeader("Generating Cobertura Report");
+				var converterExe = new CoberturaResolver().Resolve(null);
+				new CoberturaRunner(_options.WorkingDirectory, converterExe, _options.Verbose).Run(ResultsFile, CoberturaFile);
+				LogFooter();
+			}
+		}
+
+		private void LogHeader(string message, bool forceLog = false)
+		{
+			if (_options.Verbose || forceLog)
+			{
+				Console.Out.WriteLine(
+					"======================================================================================================================================================");
+				Console.Out.WriteLine($"\t{message}");
+				Console.Out.WriteLine(
+					"------------------------------------------------------------------------------------------------------------------------------------------------------");
+			}
+		}
+
+		private void LogFooter()
+		{
+			if (_options.Verbose)
+			{
+				Console.Out.WriteLine(
+					"======================================================================================================================================================");
+			}
+		}
+	}
 }

--- a/duanemckdev.dotnet.tools.testx/duanemckdev.dotnet.tools.testx.csproj
+++ b/duanemckdev.dotnet.tools.testx/duanemckdev.dotnet.tools.testx.csproj
@@ -58,7 +58,11 @@ Added option to pass in arbitrary OpenCover options</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="CommandLineParser" Version="2.2.1" />
+      <PackageReference Include="CommandLineParser" Version="2.4.3" />
+      <PackageReference Include="dotnet-opencover" Version="0.1.2" />
+      <PackageReference Include="OpenCover" Version="4.7.922" />
+      <PackageReference Include="OpenCoverToCoberturaConverter" Version="0.3.4" />
+      <PackageReference Include="ReportGenerator" Version="4.0.15" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
I have noticed that when working on a solution there is some issue when there is a space in the file path. 
this update will allow for specifying the --working-directory option to set the working directory on 

- OpenCover
- ReportGenerator
- CoberturaRunner

it also returns sub projects with a relative path to the working directory. 